### PR TITLE
Use upstream constraints for Jinja2 and Markupsafe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: cf5104777571b2b7f06fa88ee08fade24563f4a0594cf4bd17d31c47b8740b4c
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -29,7 +29,8 @@ requirements:
     - babel >=1.3
     - docutils >=0.14,<0.18
     - imagesize
-    - jinja2 >=2.3
+    - jinja2 >=2.3,<3.0
+    - markupsafe <2.0
     - packaging
     - pygments >=2.0
     - python


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

The main benefit of this is to satisfy `pip check` so that `pip install -e .` on a project using sphinx does not cause pip to overwrite the conda packages for MarkupSafe and Jinja2 (see [the install_requires here](https://github.com/sphinx-doc/sphinx/blob/bde181674d8a136358ff0a1ca991006bf23f489c/setup.py#L24-L25
)). I see that sphinx has fixed Jinja2 3 compatibility upstream but I don't know when a release with the fixes will be published.