### PR TITLE
Remove bounds on jinja2 and markupsafe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b5c2ae4120bf00c799ba9b3699bc895816d272d120080fbc967292f29b52b48c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -29,8 +29,7 @@ requirements:
     - babel >=1.3
     - docutils >=0.14,<0.18
     - imagesize
-    - jinja2 >=2.3,<3.0
-    - markupsafe <2.0
+    - jinja2 >=2.3
     - packaging
     - pygments >=2.0
     - python


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR removes the bounds added in #99 now that 4.0.2 added support for Jinja2 version 3.
