### PR TITLE
Set lower pins for sphinxcontrib

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 3092d929cd807926d846018f2ace47ba2f3b671b309c7a89cd3306e80c826b13
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -38,10 +38,10 @@ requirements:
     - snowballstemmer >=1.1
     - sphinxcontrib-applehelp
     - sphinxcontrib-devhelp
-    - sphinxcontrib-htmlhelp
+    - sphinxcontrib-htmlhelp >=2.0.0
     - sphinxcontrib-jsmath
     - sphinxcontrib-qthelp
-    - sphinxcontrib-serializinghtml
+    - sphinxcontrib-serializinghtml >=1.1.5
     # only _strictly_ a windows dependency, but appeases `pip check`
     - colorama >=0.3.5
 


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/pull/9448 for more context, but `sphinx-build` breaks with versions of these `sphinxcontrib` dependencies if they aren't at a high-enough version

The error in question is:
```
Extension error:
Could not import extension sphinx.builders.epub3 (exception: cannot import name 'RemovedInSphinx40Warning' from 'sphinx.deprecation' 
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
