### PR TITLE
Allow docutils 0.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 464d9c1bd5613bcebe76b46658763f3f3dbb184da7406e632a84596d3cd8ee90
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -27,7 +27,7 @@ requirements:
     - python >=3.6
     - alabaster >=0.7,<0.8
     - babel >=1.3
-    - docutils >=0.14,<0.18
+    - docutils >=0.14,<0.19
     - imagesize
     - importlib-metadata >=4.4
     - jinja2 >=2.3


### PR DESCRIPTION
Upstream now [supports docutils 0.18](https://github.com/sphinx-doc/sphinx/pull/10164), released as part of [the 5.0.0 release](https://www.sphinx-doc.org/en/master/changes.html)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
