### PR TITLE
Drop Python 3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ba3224a4e206e1fbdecf98a4fae4992ef9b24b85ebf7b584bb340156eaf08d89
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -20,11 +20,11 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.7
     - pip
     - babel
   run:
-    - python >=3.6
+    - python >=3.7
     - alabaster >=0.7,<0.8
     - babel >=1.3
     - docutils >=0.14,<0.20
@@ -33,7 +33,6 @@ requirements:
     - jinja2 >=2.3
     - packaging
     - pygments >=2.0
-    - python
     - requests >=2.5.0
     - snowballstemmer >=1.1
     - sphinxcontrib-applehelp


### PR DESCRIPTION
Following the updating of `docutils` dependency in https://github.com/conda-forge/sphinx-feedstock/pull/125, I noticed that [3.6 support was dropped in docutils 0.19](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-19-2022-07-05) (conda-forge also [doesn't build py36 wheels anymore](https://anaconda.org/conda-forge/docutils/files)), while py36 still officially [supported by sphinx](https://github.com/sphinx-doc/sphinx/blob/3d6d501a43d2e5942153baa9414a4de34323c56b/setup.py#L10-L12).

Trying it now, seems like the last version that resolves in a coherent py36 environment is sphinx 3.5.4:
```
(py36) ~ via  py36 ❯ conda install sphinx
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /usr/local/Caskroom/miniconda/base/envs/py36

  added / updated specs:
    - sphinx


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    alabaster-0.7.12           |             py_0          15 KB  conda-forge
    babel-2.10.3               |     pyhd8ed1ab_0         6.7 MB  conda-forge
    docutils-0.16              |   py36h79c6626_3         735 KB  conda-forge
    imagesize-1.4.1            |     pyhd8ed1ab_0          10 KB  conda-forge
    jinja2-2.11.3              |     pyhd8ed1ab_2          94 KB  conda-forge
    markupsafe-1.1.1           |   py36hfa26744_3          25 KB  conda-forge
    requests-2.12.5            |           py36_0         773 KB  conda-forge
    snowballstemmer-2.2.0      |     pyhd8ed1ab_0          57 KB  conda-forge
    sphinx-3.5.4               |     pyh44b312d_0         1.4 MB  conda-forge
    sphinxcontrib-applehelp-1.0.2|             py_0          28 KB  conda-forge
    sphinxcontrib-devhelp-1.0.2|             py_0          22 KB  conda-forge
    sphinxcontrib-htmlhelp-2.0.0|     pyhd8ed1ab_0          31 KB  conda-forge
    sphinxcontrib-jsmath-1.0.1 |             py_0           7 KB  conda-forge
    sphinxcontrib-qthelp-1.0.3 |             py_0          25 KB  conda-forge
    sphinxcontrib-serializinghtml-1.1.5|     pyhd8ed1ab_2          27 KB  conda-forge
    ------------------------------------------------------------
                                           Total:         9.9 MB
```

So I suggest dropping python 3.6 from the recipe for transparency

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
