### PR TITLE
add runtime dependency on tomli

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 30d03bbaa53b77d38863fd6b95cc4edb4a84a1512787b3b0c12fb3b4fb25d9e9
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -35,6 +35,7 @@ requirements:
     - packaging >=21.0
     - pygments >=2.14
     - requests >=2.25.0
+    - tomli >=2.0  # [py<311]
     - snowballstemmer >=2.0
     - sphinxcontrib-applehelp
     - sphinxcontrib-devhelp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - packaging >=21.0
     - pygments >=2.14
     - requests >=2.25.0
-    - tomli >=2.0  # [py<311]
+    - tomli >=2.0
     - snowballstemmer >=2.0
     - sphinxcontrib-applehelp
     - sphinxcontrib-devhelp


### PR DESCRIPTION
Sphinx v7.3.5 added a dependency on `tomli>=2.0` for Python versions prior to 3.11.

* https://www.sphinx-doc.org/en/master/changes.html#release-7-3-1-released-apr-17-2024
* https://github.com/sphinx-doc/sphinx/blob/da4c6a783066f0eb711f109461275415f99e3568/pyproject.toml#L75
* https://github.com/sphinx-doc/sphinx/commit/8a944ac87c1fb443ab4b9d08bae3a9318d164bbf

That change didn't make it into the v7.3.5 build here on `conda-forge` (#159). As a result, in a pre-Python-3.11 environment, trying to import any `sphinx` import paths that hit that `tomli` dependency results in errors like this:

```text
Running Sphinx v7.3.5

Extension error:
Could not import extension sphinx.builders.changes (exception: No module named 'tomli')
make: *** [Makefile:20: dirhtml] Error 2
Error: Process completed with exit code 2.
```

This proposes adding that runtime dependency on `tomli` to the recipe.

Thanks for your time and consideration.

### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.